### PR TITLE
Create SearchFragment UI

### DIFF
--- a/app/src/main/java/com/example/foodapp/SearchFragment.java
+++ b/app/src/main/java/com/example/foodapp/SearchFragment.java
@@ -1,25 +1,83 @@
 package com.example.foodapp;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
-
-import androidx.fragment.app.Fragment;
-
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.ImageButton;
+
+import androidx.fragment.app.Fragment;
+import androidx.navigation.Navigation;
 
 public class SearchFragment extends Fragment {
 
+    private EditText searchEditText;
+    private ImageButton backButton;
+
     public SearchFragment() {}
-
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_search, container, false);
+        View view = inflater.inflate(R.layout.fragment_search, container, false);
+
+        searchEditText = view.findViewById(R.id.ed_search_toolbar);
+        backButton =view.findViewById(R.id.back_Button);
+
+        backButton.setOnClickListener(view1 -> {
+            navigateToMainFragment();
+
+        });
+
+        setupSearchEditText();
+
+        return view;
+    }
+
+    private void navigateToMainFragment() {
+        Navigation.findNavController(getView()).navigate(R.id.action_searchFragment_to_mainFragment);
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void setupSearchEditText() {
+        searchEditText.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) {
+                searchEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.baseline_clear_24, 0);
+            } else {
+                searchEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.baseline_search, 0);
+            }
+        });
+
+        searchEditText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (s.length() > 0) {
+                    searchEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.baseline_clear_24, 0);
+                } else {
+                    searchEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.baseline_search, 0);
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+
+        searchEditText.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_UP) {
+                int drawableEndX = searchEditText.getRight() - searchEditText.getPaddingRight();
+                if (event.getRawX() >= drawableEndX - searchEditText.getCompoundDrawables()[2].getBounds().width()) {
+                    searchEditText.setText("");
+                    return true;
+                }
+            }
+            return false;
+        });
     }
 }

--- a/app/src/main/res/drawable/baseline_arrow_back_32.xml
+++ b/app/src/main/res/drawable/baseline_arrow_back_32.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="32dp" android:tint="#626160" android:viewportHeight="24" android:viewportWidth="24" android:width="32dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_clear_24.xml
+++ b/app/src/main/res/drawable/baseline_clear_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#EF603F" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+    
+</vector>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,14 +1,117 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".SearchFragment">
 
-    <TextView
-        android:gravity="center"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="SearchFragment" />
+        android:orientation="vertical"
+        android:layout_margin="8dp">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tool_bar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/white">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageButton
+                    android:id="@+id/back_Button"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:src="@drawable/baseline_arrow_back_32"/>
+
+                <EditText
+                    android:id="@+id/ed_search_toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:paddingHorizontal="8dp"
+                    android:hint="@string/search"
+                    android:textSize="18sp"
+                    android:singleLine="true"
+                    android:gravity="start|center"
+                    android:background="@drawable/edittext_shape"
+                    android:drawableEnd="@drawable/baseline_search"/>
+            </LinearLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="12dp">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chipGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="4dp"
+                app:singleSelection="false">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_all"
+                    style="@style/Widget.MaterialComponents.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/all"
+                    android:textStyle="bold"
+                    android:textSize="16sp"
+                    android:checkable="true"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_category"
+                    style="@style/Widget.MaterialComponents.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/category"
+                    android:textStyle="bold"
+                    android:textSize="16sp"
+                    app:chipBackgroundColor="@color/white2"
+                    android:checkable="true"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_country"
+                    style="@style/Widget.MaterialComponents.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/country"
+                    android:textStyle="bold"
+                    android:textSize="16sp"
+                    app:chipBackgroundColor="@color/white2"
+                    android:checkable="true"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_ingredient"
+                    style="@style/Widget.MaterialComponents.Chip.Filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/ingredient"
+                    android:textStyle="bold"
+                    android:textSize="16sp"
+                    app:chipBackgroundColor="@color/white2"
+                    android:checkable="true"/>
+            </com.google.android.material.chip.ChipGroup>
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginHorizontal="8dp"
+            tools:listitem="@layout/item_card_search"/>
+    </LinearLayout>
 
 </FrameLayout>
+

--- a/app/src/main/res/layout/item_card_search.xml
+++ b/app/src/main/res/layout/item_card_search.xml
@@ -1,0 +1,64 @@
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/itemCard"
+    android:layout_width="match_parent"
+    android:layout_height="130dp"
+    android:layout_margin="8dp"
+    android:elevation="4dp"
+    android:radius="16dp"
+    app:cardBackgroundColor="@color/splash_background"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="6dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp">
+
+        <ImageView
+            android:id="@+id/mealImage"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:scaleType="fitXY"
+            android:layout_gravity=""
+            android:src="@drawable/img_meal_day"/>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:id="@+id/mealName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/meal_name"
+                android:textAppearance="?android:textAppearanceLarge" />
+
+            <TextView
+                android:id="@+id/mealCountry"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/country"
+                android:textAppearance="?android:textAppearanceSmall" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_favourite"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:backgroundTint="@android:color/holo_green_light"
+        android:layout_gravity="end|bottom"
+        />
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,9 @@
     <string name="lunch">Lunch</string>
     <string name="dinner">Dinner</string>
     <string name="country">Country</string>
+    <string name="all">All</string>
+    <string name="category">Category</string>
+    <string name="ingredient">Ingredient</string>
+    <string name="search">Search</string>
+    <string name="add_favourite">Add Favourite</string>
 </resources>


### PR DESCRIPTION
- Create `SearchFragment` layout with:
  - Toolbar with back button and search `EditText`.
  - Chip group to filter search results.
  - RecyclerView to show search result
- Handler Some `SearchFragment` logic:
  - Navigate back to main fragment.
  - Clear text from search `EditText`.
  - Change the end icon based on focus and text input.
- Create `item_card_search.xml` for showing items in RecyclerView
- Add `baseline_arrow_back_32` and `baseline_clear_24` in drawable folder
- Update `strings.xml` file.