### PR TITLE
Updated splash screen and user login persistence

### DIFF
--- a/app/src/main/java/com/example/foodapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/foodapp/ProfileFragment.java
@@ -1,64 +1,60 @@
 package com.example.foodapp;
 
+import static android.content.Context.MODE_PRIVATE;
+
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.navigation.Navigation;
 
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
-/**
- * A simple {@link Fragment} subclass.
- * Use the {@link ProfileFragment#newInstance} factory method to
- * create an instance of this fragment.
- */
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.firebase.auth.FirebaseAuth;
+
 public class ProfileFragment extends Fragment {
+    private Button btnLogout;
+    private GoogleSignInClient mGoogleSignInClient;  // ✅ Declare GoogleSignInClient
 
-    // TODO: Rename parameter arguments, choose names that match
-    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-    private static final String ARG_PARAM1 = "param1";
-    private static final String ARG_PARAM2 = "param2";
-
-    // TODO: Rename and change types of parameters
-    private String mParam1;
-    private String mParam2;
-
-    public ProfileFragment() {
-        // Required empty public constructor
-    }
-
-    /**
-     * Use this factory method to create a new instance of
-     * this fragment using the provided parameters.
-     *
-     * @param param1 Parameter 1.
-     * @param param2 Parameter 2.
-     * @return A new instance of fragment ProfileFragment.
-     */
-    // TODO: Rename and change types and number of parameters
-    public static ProfileFragment newInstance(String param1, String param2) {
-        ProfileFragment fragment = new ProfileFragment();
-        Bundle args = new Bundle();
-        args.putString(ARG_PARAM1, param1);
-        args.putString(ARG_PARAM2, param2);
-        fragment.setArguments(args);
-        return fragment;
-    }
+    public ProfileFragment() {}
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (getArguments() != null) {
-            mParam1 = getArguments().getString(ARG_PARAM1);
-            mParam2 = getArguments().getString(ARG_PARAM2);
-        }
+        GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestEmail()
+                .build();
+        mGoogleSignInClient = GoogleSignIn.getClient(requireActivity(), gso);
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_profile, container, false);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_profile, container, false);
+        btnLogout = view.findViewById(R.id.btn_logout);
+
+        btnLogout.setOnClickListener(v -> logOut());
+
+        return view;
+    }
+
+    private void logOut() {
+        SharedPreferences sharedPreferences = requireContext().getSharedPreferences("UserPrefs", MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.clear();
+        editor.apply();
+
+        FirebaseAuth.getInstance().signOut();
+
+        mGoogleSignInClient.revokeAccess().addOnCompleteListener(task ->
+                Navigation.findNavController(requireView()).navigate(R.id.action_mainFragment_to_loginFragment)
+        );
     }
 }

--- a/app/src/main/java/com/example/foodapp/RegisterFragment.java
+++ b/app/src/main/java/com/example/foodapp/RegisterFragment.java
@@ -1,7 +1,11 @@
 package com.example.foodapp;
 
+import static android.content.Context.MODE_PRIVATE;
+
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -131,6 +135,7 @@ public class RegisterFragment extends Fragment {
                     btnRegister.setEnabled(true);
                     FirebaseUser user = mAuth.getCurrentUser();
                     if (user != null) {
+                        saveUserLoginState();
                         Navigation.findNavController(requireView()).navigate(R.id.action_registerFragment_to_mainFragment);
                     }
                 })
@@ -157,7 +162,11 @@ public class RegisterFragment extends Fragment {
         mAuth.createUserWithEmailAndPassword(email, password)
                 .addOnSuccessListener(authResult -> {
                     btnRegister.setEnabled(true);
-                    Navigation.findNavController(requireView()).navigate(R.id.action_registerFragment_to_mainFragment);
+                    FirebaseUser user = mAuth.getCurrentUser();
+                    if (user != null) {
+                        saveUserLoginState();
+                        Navigation.findNavController(requireView()).navigate(R.id.action_registerFragment_to_mainFragment);
+                    }
                 })
                 .addOnFailureListener(e -> {
                     btnRegister.setEnabled(true);
@@ -172,4 +181,11 @@ public class RegisterFragment extends Fragment {
                     }
                 });
     }
+    private void saveUserLoginState() {
+        SharedPreferences sharedPreferences = requireContext().getSharedPreferences("UserPrefs", MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean("IS_LOGGED_IN", true);
+        editor.apply();
+    }
+
 }

--- a/app/src/main/java/com/example/foodapp/SplashFragment.java
+++ b/app/src/main/java/com/example/foodapp/SplashFragment.java
@@ -1,7 +1,12 @@
 package com.example.foodapp;
 
+import static android.content.Context.MODE_PRIVATE;
+
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 
@@ -10,23 +15,43 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-public class SplashFragment extends Fragment {
+import com.google.firebase.auth.FirebaseAuth;
 
+public class SplashFragment extends Fragment {
 
     public SplashFragment() {}
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_splash, container, false);
+        return inflater.inflate(R.layout.fragment_splash, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        if (checkUserLogin(view)) {
+            return;
+        }
+
         new Handler().postDelayed(() -> {
             Navigation.findNavController(view).navigate(R.id.action_splashFragment_to_loginFragment);
         }, 3000);
-        return view;
+    }
+
+    private boolean checkUserLogin(View view) {
+        SharedPreferences sharedPreferences = requireContext().getSharedPreferences("UserPrefs", MODE_PRIVATE);
+        boolean isLoggedIn = sharedPreferences.getBoolean("IS_LOGGED_IN", false);
+
+        if (isLoggedIn && FirebaseAuth.getInstance().getCurrentUser() != null) {
+            Navigation.findNavController(view).navigate(R.id.action_splashFragment_to_mainFragment);
+            return true;
+        }
+        return false;
     }
 }

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -101,23 +101,6 @@
             android:layout_marginHorizontal="28dp"
             android:layout_marginVertical="12dp">
 
-            <CheckBox
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_gravity="center_vertical"
-                android:background="@drawable/checkbox_selector"
-                android:button="@null"
-                android:checked="false"
-                />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/remember_me"
-                android:textColor="@color/dark_blue"
-                android:textSize="16sp"
-                android:layout_marginStart="4dp"
-                />
             <Space
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -13,6 +13,9 @@
         <action
             android:id="@+id/action_splashFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
+        <action
+            android:id="@+id/action_splashFragment_to_mainFragment"
+            app:destination="@id/mainFragment" />
     </fragment>
     <fragment
         android:id="@+id/loginFragment"
@@ -50,6 +53,9 @@
         <action
             android:id="@+id/action_mainFragment_to_mealDetailsFragment"
             app:destination="@id/mealDetailsFragment" />
+        <action
+            android:id="@+id/action_mainFragment_to_loginFragment"
+            app:destination="@id/loginFragment" />
     </fragment>
     <fragment
         android:id="@+id/searchFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="example_ingredient">Place the raisins and prunes into a small bowl and pour over enough water to cover. Add lemon juice and let soak for at least 1 hour.</string>
     <string name="instructions">Instructions</string>
     <string name="example_instructions">Place the raisins and prunes into a small bowl and pour over enough water to cover. Add lemon juice and let soak for at least 1 hour.</string>
+    <string name="default_web_client_id">921088706382-vfnt0i84hfnlnm0vl4mku08jv1m6a1mr.apps.googleusercontent.com</string>
 
 
 </resources>


### PR DESCRIPTION
This commit updates the splash screen functionality and implements user login persistence to improve the user experience.

**Splash Screen:**
- Added logic to check if the user is already logged in.
- If the user is logged in, it navigates to the main fragment directly.

**User Login Persistence:**
- Added `SharedPreferences` to store the user's login state.
- When the user logs in, the login state is saved.
- Updated `LoginFragment` to save user login data in shared preferences.
- Updated `RegisterFragment` to save user login data in shared preferences after registration.
- Updated `SplashFragment` to redirect to the main screen if the user is logged in.
- Created `ProfileFragment` to implement the logout feature.
- Added a logic in `ProfileFragment` to clear saved shared preferences and log out the user from both Firebase and Google accounts.

**Layout Changes:**
- Removed the checkbox from `fragment_login.xml`

**Navigation Changes:**
- Added a new navigation action from `splashFragment` to `mainFragment` in `nav_graph.xml`
- Added a new navigation action from `mainFragment` to `loginFragment` in `nav_graph.xml`