### PR TITLE
Refactor: Replace Callback with RxJava in API calls

### DIFF
--- a/app/src/main/java/com/example/foodapp/data/remote/ApiCallback.java
+++ b/app/src/main/java/com/example/foodapp/data/remote/ApiCallback.java
@@ -1,6 +1,0 @@
-package com.example.foodapp.data.remote;
-
-public interface ApiCallback<T> {
-    void onSuccess(T result);
-    void onFailure(String errorMessage);
-}

--- a/app/src/main/java/com/example/foodapp/data/remote/IPApi/IpApiClient.java
+++ b/app/src/main/java/com/example/foodapp/data/remote/IPApi/IpApiClient.java
@@ -1,10 +1,6 @@
 package com.example.foodapp.data.remote.IPApi;
 
-import com.example.foodapp.data.remote.model.CountryMapper;
-import com.example.foodapp.data.remote.ApiCallback;
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
+import hu.akarnokd.rxjava3.retrofit.RxJava3CallAdapterFactory;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -17,30 +13,9 @@ public class IpApiClient {
             retrofit = new Retrofit.Builder()
                     .baseUrl(BASE_URL)
                     .addConverterFactory(GsonConverterFactory.create())
+                    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                     .build();
         }
         return retrofit;
-    }
-
-    public static <T> void makeNetworkCall(Call<T> call, ApiCallback<T> callback) {
-        call.enqueue(new Callback<T>() {
-            @Override
-            public void onResponse(Call<T> call, Response<T> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    callback.onSuccess(response.body());
-                } else {
-                    callback.onFailure("Error: Response is null or unsuccessful");
-                }
-            }
-
-            @Override
-            public void onFailure(Call<T> call, Throwable t) {
-                callback.onFailure("Network Error: " + t.getMessage());
-            }
-        });
-    }
-
-    public static String formatCountryForMealDB(String country) {
-        return CountryMapper.getMappedCountry(country);
     }
 }

--- a/app/src/main/java/com/example/foodapp/data/remote/IPApi/IpApiService.java
+++ b/app/src/main/java/com/example/foodapp/data/remote/IPApi/IpApiService.java
@@ -1,9 +1,10 @@
 package com.example.foodapp.data.remote.IPApi;
 
+import io.reactivex.rxjava3.core.Single;
 import retrofit2.Call;
 import retrofit2.http.GET;
 
 public interface IpApiService {
     @GET("json/")
-    Call<IpApiResponse> getIpInfo();
+    Single<IpApiResponse> getIpInfo();
 }

--- a/app/src/main/java/com/example/foodapp/data/remote/MealApi/ApiClient.java
+++ b/app/src/main/java/com/example/foodapp/data/remote/MealApi/ApiClient.java
@@ -1,10 +1,6 @@
 package com.example.foodapp.data.remote.MealApi;
 
-import com.example.foodapp.data.remote.ApiCallback;
-
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
+import hu.akarnokd.rxjava3.retrofit.RxJava3CallAdapterFactory;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -17,26 +13,9 @@ public class ApiClient {
             retrofit = new Retrofit.Builder()
                     .baseUrl(BASE_URL)
                     .addConverterFactory(GsonConverterFactory.create())
+                    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                     .build();
         }
         return retrofit;
-    }
-
-    public static <T> void makeNetworkCall(Call<T> call, ApiCallback<T> callback) {
-        call.enqueue(new Callback<T>() {
-            @Override
-            public void onResponse(Call<T> call, Response<T> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    callback.onSuccess(response.body());
-                } else {
-                    callback.onFailure("Error: " + response.message());
-                }
-            }
-
-            @Override
-            public void onFailure(Call<T> call, Throwable t) {
-                callback.onFailure("Network Error: " + t.getMessage());
-            }
-        });
     }
 }

--- a/app/src/main/java/com/example/foodapp/data/remote/MealApi/ApiService.java
+++ b/app/src/main/java/com/example/foodapp/data/remote/MealApi/ApiService.java
@@ -1,27 +1,29 @@
 package com.example.foodapp.data.remote.MealApi;
 
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
 public interface ApiService {
     @GET("categories.php")   // Endpoint for fetching all categories
-    Call<CategoriesResponse> getCategories();
+    Observable<CategoriesResponse> getCategories();
 
     @GET("list.php?a=list")  // Endpoint for fetching all areas
-    Call<AreasResponse> getAreas();
+    Observable<AreasResponse> getAreas();
 
     @GET("list.php?i=list")  // Endpoint for fetching all ingredients
-    Call<IngredientResponse> getIngredients();
+    Observable<IngredientResponse> getIngredients();
 
     @GET("filter.php?") // Endpoint for fetching meals by area
-    Call<MealsCountryResponse> getMealsByArea(@Query("a") String area);
+    Observable<MealsCountryResponse> getMealsByArea(@Query("a") String area);
 
     @GET("random.php") // Endpoint for fetching a random meal
-    Call<MealResponse> getRandomMeal();
+    Single<MealResponse> getRandomMeal();
 
     @GET("lookup.php?") // Endpoint for fetching meal by mealId
-    Call<MealResponse> getMealsById(@Query("i") String mealId);
+    Single<MealResponse> getMealsById(@Query("i") String mealId);
 
 
 }

--- a/app/src/main/java/com/example/foodapp/data/repository/HomeRepository.java
+++ b/app/src/main/java/com/example/foodapp/data/repository/HomeRepository.java
@@ -1,6 +1,5 @@
 package com.example.foodapp.data.repository;
 
-import com.example.foodapp.data.remote.ApiCallback;
 import com.example.foodapp.data.remote.MealApi.ApiClient;
 import com.example.foodapp.data.remote.MealApi.ApiService;
 import com.example.foodapp.data.remote.MealApi.AreasResponse;
@@ -9,7 +8,8 @@ import com.example.foodapp.data.remote.MealApi.IngredientResponse;
 import com.example.foodapp.data.remote.MealApi.MealResponse;
 import com.example.foodapp.data.remote.MealApi.MealsCountryResponse;
 
-import retrofit2.Call;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 
 public class HomeRepository {
 
@@ -19,34 +19,28 @@ public class HomeRepository {
         this.apiService = ApiClient.getClient().create(ApiService.class);
     }
 
-    public void fetchMealDetailsFromAPI(String mealId, ApiCallback callback) {
-        Call<MealResponse> call = apiService.getMealsById(mealId);
-        ApiClient.makeNetworkCall(call, callback);
+    public Single<MealResponse> fetchMealDetailsFromAPI(String mealId) {
+        return apiService.getMealsById(mealId);
     }
 
-    public void fetchRandomMealFromAPI(ApiCallback callback) {
-        Call<MealResponse> call = apiService.getRandomMeal();
-        ApiClient.makeNetworkCall(call, callback);
+    public Single<MealResponse> fetchRandomMealFromAPI() {
+        return apiService.getRandomMeal();
     }
 
-    public void fetchPopularMealsFromAPI(String country, ApiCallback callback) {
-        Call<MealsCountryResponse> call = apiService.getMealsByArea(country);
-        ApiClient.makeNetworkCall(call, callback);
+    public Observable<MealsCountryResponse> fetchPopularMealsFromAPI(String country) {
+        return apiService.getMealsByArea(country);
     }
 
-    public void fetchCategoriesFromAPI(ApiCallback callback) {
-        Call<CategoriesResponse> call = apiService.getCategories();
-        ApiClient.makeNetworkCall(call, callback);
+    public Observable<CategoriesResponse> fetchCategoriesFromAPI() {
+        return apiService.getCategories();
     }
 
-    public void fetchCountriesFromAPI(ApiCallback callback) {
-        Call<AreasResponse> call = apiService.getAreas();
-        ApiClient.makeNetworkCall(call, callback);
+    public Observable<AreasResponse> fetchCountriesFromAPI() {
+        return apiService.getAreas();
     }
 
-    public void fetchIngredientsFromAPI(ApiCallback callback) {
-        Call<IngredientResponse> call = apiService.getIngredients();
-        ApiClient.makeNetworkCall(call, callback);
+    public Observable<IngredientResponse> fetchIngredientsFromAPI() {
+        return apiService.getIngredients();
     }
 
 }

--- a/app/src/main/java/com/example/foodapp/data/repository/LocationRepository.java
+++ b/app/src/main/java/com/example/foodapp/data/repository/LocationRepository.java
@@ -3,8 +3,8 @@ package com.example.foodapp.data.repository;
 import com.example.foodapp.data.remote.IPApi.IpApiClient;
 import com.example.foodapp.data.remote.IPApi.IpApiResponse;
 import com.example.foodapp.data.remote.IPApi.IpApiService;
-import com.example.foodapp.data.remote.ApiCallback;
-import retrofit2.Call;
+
+import io.reactivex.rxjava3.core.Single;
 
 public class LocationRepository {
     private final IpApiService ipApiService;
@@ -12,8 +12,7 @@ public class LocationRepository {
         this.ipApiService = IpApiClient.getClient().create(IpApiService.class);
     }
 
-    public void fetchLocationFromAPI(ApiCallback<IpApiResponse> callback) {
-        Call<IpApiResponse> call = ipApiService.getIpInfo();
-        IpApiClient.makeNetworkCall(call, callback);
+    public Single<IpApiResponse> fetchLocationFromAPI() {
+        return ipApiService.getIpInfo();
     }
 }

--- a/app/src/main/java/com/example/foodapp/ui/home/view/HomeFragment.java
+++ b/app/src/main/java/com/example/foodapp/ui/home/view/HomeFragment.java
@@ -18,6 +18,7 @@ import com.example.foodapp.data.remote.model.Ingredient;
 import com.example.foodapp.data.remote.model.Meal;
 import com.example.foodapp.data.repository.HomeRepository;
 import com.example.foodapp.data.repository.LocationRepository;
+import com.example.foodapp.ui.PopupSnackbar;
 import com.example.foodapp.ui.home.presenter.HomePresenter;
 
 import java.io.Serializable;
@@ -102,6 +103,11 @@ public class HomeFragment extends Fragment implements onClickListener, HomeView 
     @Override
     public void showIngredients(List<Ingredient> ingredients) {
         recyclerView4.setAdapter(new IngredientAdapter(getContext(), ingredients, this));
+    }
+
+    @Override
+    public void showAlert(String message, boolean flag) {
+        new PopupSnackbar(getContext()).showMessage(message,flag);
     }
 
     @Override

--- a/app/src/main/java/com/example/foodapp/ui/home/view/HomeView.java
+++ b/app/src/main/java/com/example/foodapp/ui/home/view/HomeView.java
@@ -14,4 +14,5 @@ public interface HomeView {
     void showIngredients(List<Ingredient> ingredients);
     void showRandomMeal(Meal meal);
     void showMealDetails(Meal meal);
+    void showAlert(String message,boolean flag);
 }


### PR DESCRIPTION
- Removed `ApiCallback` interface.
- Refactored `HomeRepository` to use RxJava's `Single` and `Observable` for API calls instead of Retrofit's `Call` and custom callbacks.
- Refactored `LocationRepository` to use `Single` for API calls.
- Modified `ApiService` to return `Single` and `Observable` instead of `Call`.
- Modified `IpApiService` to return `Single` instead of `Call`.
- Updated `HomePresenter` to use RxJava for handling API responses and errors, including using `subscribeOn` and `observeOn`.
- Removed `makeNetworkCall` method from `ApiClient` and `IpApiClient`.
- Added `RxJava3CallAdapterFactory` to Retrofit builders in `ApiClient` and `IpApiClient`.
- Added `showAlert` to `HomeView` to handle displaying error messages.
- Added `PopupSnackbar` to `HomeFragment` to display error messages.
